### PR TITLE
Fixed Raindrop problem runner.

### DIFF
--- a/exercises/raindrops/runner.mips
+++ b/exercises/raindrops/runner.mips
@@ -107,4 +107,4 @@ clear_output:
         jr      $ra
 
 # # Include your implementation here if you wish to run this from the MARS GUI.
-# .include "example.mips"
+# .include "impl.mips"


### PR DESCRIPTION
Should include `impl.mips` instead of `example.mips`

All the other exercises include "impl.mips". It might be nice if they each included a source file named after the problem, but that would be a separate PR I think.