### PR TITLE
Added first draft of difference-of-squares exercise.

### DIFF
--- a/config.json
+++ b/config.json
@@ -10,6 +10,7 @@
     "trinary",
     "hexadecimal",
     "leap",
+    "difference-of-squares",
     "hamming",
     "rna-transcription",
     "isogram",

--- a/exercises/difference-of-squares/example.mips
+++ b/exercises/difference-of-squares/example.mips
@@ -1,0 +1,35 @@
+.globl difference_of_squares
+
+#
+# Compute the difference between the sum of squares.
+#
+# Variables:
+#
+# $a0 - given value (as an int)
+# $v0 - final value - difference of squares
+# $t0 - square of sum
+# $t1 - sum of squares
+
+difference_of_squares:
+
+        move    $v0, $zero      # clear result
+        move    $t0, $zero      # clear square of sum
+        move    $t1, $zero      # clear sum of squares
+
+loop:
+        beqz    $a0, done       # if number is zero, we're done
+        add     $t0, $t0, $a0   # add number to sum
+
+        mult    $a0, $a0        # square number
+        mflo    $t2
+        add     $t1, $t1, $t2   # add to sum of squares
+        addi    $a0, $a0, -1    # decrement number
+        j       loop
+
+done:
+        mult    $t0, $t0        # square sum
+        mflo    $t0
+
+        sub     $v0, $t0, $t1   # find difference
+
+        jr $ra

--- a/exercises/difference-of-squares/runner.mips
+++ b/exercises/difference-of-squares/runner.mips
@@ -1,0 +1,88 @@
+#
+# Test difference_of_squares with some examples
+#
+# s0 - num of tests left to run
+# s1 - address of input word
+# s2 - address of expected output word
+# s3 - input word
+# s4 - output word
+#
+# difference_of_squares must:
+# - be named difference_of_squares and declared as global
+# - read input integer from a0
+# - follow the convention of using the t0-9 registers for temporary storage
+# - (if it wants to use s0-7 then it is responsible for pushing existing values to the stack then popping them back off before returning)
+# - write integer result to v0
+
+.data
+
+n: .word 4                             # number of test cases
+ins:  .word    0,   5,   10,      100  # input numbers
+outs: .word    0, 170, 2640, 25164150  # expected result
+
+failmsg: .asciiz "failed for test input: "
+expectedmsg: .asciiz ". expected "
+tobemsg: .asciiz " to be "
+okmsg: .asciiz "all tests passed"
+
+
+.text
+
+runner:
+        lw      $s0, n
+        la      $s1, ins
+        la      $s2, outs
+
+run_test:
+        lw      $s3, 0($s1)             # read input from memory
+        move    $a0, $s3                # move it to a0
+        jal     difference_of_squares   # call subroutine under test
+        move    $v1, $v0                # move return value in v0 to v1 because we need v0 for syscall
+
+        lw      $s4, 0($s2)             # read expected output from memory
+        bne     $v1, $s4, exit_fail     # if expected doesn't match actual, jump to fail
+
+        addi    $s1, $s1, 4             # move to next word in input
+        addi    $s2, $s2, 4             # move to next word in output
+        sub     $s0, $s0, 1             # decrement num of tests left to run
+        bgt     $s0, $zero, run_test    # if more than zero tests to run, jump to run_test
+
+exit_ok:
+        la      $a0, okmsg              # put address of okmsg into a0
+        li      $v0, 4                  # 4 is print string
+        syscall
+
+        li      $v0, 10                 # 10 is exit with zero status (clean exit)
+        syscall
+
+exit_fail:
+        la      $a0, failmsg            # put address of failmsg into a0
+        li      $v0, 4                  # 4 is print string
+        syscall
+
+        move    $a0, $s3                # set arg of syscall to input that failed the test
+        li      $v0, 1                  # 1 is print int
+        syscall
+
+        la      $a0, expectedmsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $v1                # print actual that failed on
+        li      $v0, 1
+        syscall
+
+        la      $a0, tobemsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $s4                # print expected value that failed on
+        li      $v0, 1
+        syscall
+
+        li      $a0, 1                  # set exit code to 1
+        li      $v0, 17                 # terminate with the exit code in $a0
+        syscall
+
+# # Include your implementation here if you wish to run this from the MARS GUI.
+# .include "impl.mips"


### PR DESCRIPTION
Unit test input taken from common repo. Only testing a single function here, unlike a lot of the other tests that test three different functions.

@ozan A lot of the other versions of this exercise expect, and test, three different functions:

* `sum_of_squares`
* `square_of_sum`
* `difference_of_squares`

However, I thought for this, we should just include the final one, as that is that the problem actually is. Added in extra subfunctions would make the runner longer, and I don't think it would help users achieve the final objective. What do you think?

Also, I don't think this is as hard as some of the later exercises, so put after `leap`. Where do you think it should go?

And can you come up with any improvements for the example? 