### PR TITLE
Outline of atbash-cipher exercise.

### DIFF
--- a/config.json
+++ b/config.json
@@ -14,6 +14,7 @@
     "rna-transcription",
     "isogram",
     "triangle",
+    "atbash-cipher",
     "scrabble-score",
     "raindrops"
   ],

--- a/exercises/atbash-cipher/example.mips
+++ b/exercises/atbash-cipher/example.mips
@@ -7,5 +7,41 @@
 
 atbash_cipher:
 
-end:
+        move    $t0, $a0                        # copy input address
+        move    $t1, $a1                        # copy output address
+        move    $t3, $zero                      # clear character written count
+
+loop:
+        lb      $t2, 0($t0)                     # load next input byte
+        beqz    $t2, done                       # if null, done
+
+        bgt     $t2, 'z', next_char             # if greater than 'z', ignore
+        bge     $t2, 'a', space_check           # if greater than or equal to 'a', proceed
+        bgt     $t2, 'Z', next_char             # if greater than 'Z', ignore
+        blt     $t2, 'A', next_char             # if less than 'A', ignore
+        addi    $t2, $t2, 32                    # convert to lower case
+
+space_check:
+        bne     $t3, 5, encode                  # if not written 5 characters yet, jump to encode
+
+        li      $t4, 32                         # write space to output
+        sb      $t4, 0($t1)
+        addi    $t1, $t1, 1                     # increment output address
+        move    $t3, $zero                      # reset character written count
+
+encode:
+        li      $t4, 'z'
+        subi    $t2, $t2, 'a'                   # calculate offset from 'a'
+        sub     $t2, $t4, $t2                   # calculate cipher character, subtract offset from 'z'
+
+        sb      $t2, 0($t1)                     # store cipher character
+        addi    $t1, $t1, 1
+        addi    $t3, $t3, 1                     # increment character written count
+
+next_char:
+        addi    $t0, $t0, 1                     # move to next input character
+        j       loop
+
+done:
+        sb      $zero, 0($t1)                   # write null terminator
         jr $ra

--- a/exercises/atbash-cipher/example.mips
+++ b/exercises/atbash-cipher/example.mips
@@ -1,0 +1,11 @@
+# Encode a string using the Atbash cipher
+#
+# $a0 - input, pointer to null-terminated input string
+# $a1 - input, pointer to output string
+
+.globl atbash_cipher
+
+atbash_cipher:
+
+end:
+        jr $ra

--- a/exercises/atbash-cipher/runner.mips
+++ b/exercises/atbash-cipher/runner.mips
@@ -123,4 +123,3 @@ clear_output:
 
 # # Include your implementation here if you wish to run this from the MARS GUI.
 # .include "impl.mips"
-.include "example.mips"

--- a/exercises/atbash-cipher/runner.mips
+++ b/exercises/atbash-cipher/runner.mips
@@ -22,7 +22,7 @@
 # number of test cases
 n: .word 5
 # input values and expected output values (all null terminated)
-ins:  .asciiz "yes", "no", "OMG", "mindblowingly",   "The quick brown fox jumps over the lazy dog"
+ins:  .asciiz "yes", "no", "OMG", "mindblowingly",   "The quick brown fox jumps over the lazy dog."
 outs: .asciiz "bvh", "ml", "lnt", "nrmwy oldrm tob", "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
 
 failmsg: .asciiz "failed for test input: "
@@ -39,15 +39,18 @@ runner:
         la      $s2, outs
 
         li      $v0, 9                  # code for allocating heap memory
-        li      $a0, 42                 # specify 42 bytes - length of longest expected output
+        li      $a0, 44                 # specify 44 bytes - length of longest expected output
         syscall
         move    $a1, $v0                # location of allocated memory is where callee writes result
         move    $s5, $v0                # also keep a copy for ourselves
 
 run_test:
         jal     clear_output            # zero out output location
-        lw      $a0, 0($s1)             # load input value into a0
+        move    $a0, $s1                # load input value into a0
+        move    $a1, $s5
         jal     atbash_cipher           # call subroutine under test
+        move    $s6, $a1                # take copy of output value
+        move    $s7, $s2
 
 scan:
         lb      $s3, 0($s2)             # load one byte of the expectation
@@ -57,8 +60,13 @@ scan:
         addi    $a1, $a1, 1             # point to next actual byte
         bne     $s3, $zero, scan        # if one char (and therefore the other) was not null, loop
 
+input_scan:
+        addi    $s1, $s1, 1
+        lb      $s3, 0($s1)
+        bne     $s3, $zero, input_scan
+
 done_scan:
-        addi    $s1, $s1, 4             # point to next input word
+        addi    $s1, $s1, 1             # point to next input word
         sub     $s0, $s0, 1             # decrement num of tests left to run
         bgt     $s0, $zero, run_test    # if more than zero tests to run, jump to run_test
 
@@ -83,7 +91,7 @@ exit_fail:
         li      $v0, 4
         syscall
 
-        move    $a0, $a1                # print actual that failed on
+        move    $a0, $s6                # print actual that failed on
         li      $v0, 4
         syscall
 
@@ -91,7 +99,7 @@ exit_fail:
         li      $v0, 4
         syscall
 
-        move    $a0, $s2                # print expected value that failed on
+        move    $a0, $s7                # print expected value that failed on
         li      $v0, 4
         syscall
 
@@ -104,6 +112,13 @@ clear_output:
         sw      $zero, 4($s5)
         sw      $zero, 8($s5)
         sw      $zero, 12($s5)
+        sw      $zero, 16($s5)
+        sw      $zero, 20($s5)
+        sw      $zero, 24($s5)
+        sw      $zero, 28($s5)
+        sw      $zero, 32($s5)
+        sw      $zero, 36($s5)
+        sw      $zero, 40($s5)
         jr      $ra
 
 # # Include your implementation here if you wish to run this from the MARS GUI.

--- a/exercises/atbash-cipher/runner.mips
+++ b/exercises/atbash-cipher/runner.mips
@@ -1,0 +1,111 @@
+#
+# Test atbash_cipher with some examples
+#
+# a0 - input string, for callee
+# a1 - pointer to output string, for callee
+# s0 - num of tests left to run
+# s1 - address of input string
+# s2 - address of expected output string
+# s3 - char byte of input
+# s4 - char byte of output
+# s5 - copy of output location
+#
+# atbash_cipher must:
+# - be named atbash_cipher and declared as global
+# - read input string from a0
+# - follow the convention of using the t0-9 registers for temporary storage
+# - (if it uses s0-7 then it is responsible for pushing existing values to the stack then popping them back off before returning)
+# - write a zero-terminated string representing the return value to address given in a1
+
+.data
+
+# number of test cases
+n: .word 5
+# input values and expected output values (all null terminated)
+ins:  .asciiz "yes", "no", "OMG", "mindblowingly",   "The quick brown fox jumps over the lazy dog"
+outs: .asciiz "bvh", "ml", "lnt", "nrmwy oldrm tob", "gsvjf rxpyi ldmul cqfnk hlevi gsvoz abwlt"
+
+failmsg: .asciiz "failed for test input: "
+expectedmsg: .asciiz ". expected "
+tobemsg: .asciiz " to be "
+okmsg: .asciiz "all tests passed"
+
+
+.text
+
+runner:
+        lw      $s0, n
+        la      $s1, ins
+        la      $s2, outs
+
+        li      $v0, 9                  # code for allocating heap memory
+        li      $a0, 42                 # specify 42 bytes - length of longest expected output
+        syscall
+        move    $a1, $v0                # location of allocated memory is where callee writes result
+        move    $s5, $v0                # also keep a copy for ourselves
+
+run_test:
+        jal     clear_output            # zero out output location
+        lw      $a0, 0($s1)             # load input value into a0
+        jal     atbash_cipher           # call subroutine under test
+
+scan:
+        lb      $s3, 0($s2)             # load one byte of the expectation
+        lb      $s4, 0($a1)             # load one byte of the actual
+        bne     $s3, $s4, exit_fail     # if the two differ, the test has failed
+        addi    $s2, $s2, 1             # point to next expectation byte
+        addi    $a1, $a1, 1             # point to next actual byte
+        bne     $s3, $zero, scan        # if one char (and therefore the other) was not null, loop
+
+done_scan:
+        addi    $s1, $s1, 4             # point to next input word
+        sub     $s0, $s0, 1             # decrement num of tests left to run
+        bgt     $s0, $zero, run_test    # if more than zero tests to run, jump to run_test
+
+exit_ok:
+        la      $a0, okmsg              # put address of okmsg into a0
+        li      $v0, 4                  # 4 is print string
+        syscall
+
+        li      $v0, 10                 # 10 is exit with zero status (clean exit)
+        syscall
+
+exit_fail:
+        la      $a0, failmsg            # put address of failmsg into a0
+        li      $v0, 4                  # 4 is print string
+        syscall
+
+        move    $a0, $s1                # print input that failed on
+        li      $v0, 4
+        syscall
+
+        la      $a0, expectedmsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $a1                # print actual that failed on
+        li      $v0, 4
+        syscall
+
+        la      $a0, tobemsg
+        li      $v0, 4
+        syscall
+
+        move    $a0, $s2                # print expected value that failed on
+        li      $v0, 4
+        syscall
+
+        li      $a0, 1                  # set error code to 1
+        li      $v0, 17                 # 17 is exit with error
+        syscall
+
+clear_output:
+        sw      $zero, 0($s5)           # zero out output by storing 4 words (16 bytes) of zeros
+        sw      $zero, 4($s5)
+        sw      $zero, 8($s5)
+        sw      $zero, 12($s5)
+        jr      $ra
+
+# # Include your implementation here if you wish to run this from the MARS GUI.
+# .include "impl.mips"
+.include "example.mips"


### PR DESCRIPTION
Got the runner working with a few unit test inputs. Example implementation is currently empty.

This is still a work-in-progress. I think the runner should work fine, but I haven't put any implementation in the example file yet. @ozan feel free to have a go at an implementation if you want :)

Need to add more unit test input from here: https://github.com/exercism/x-common/blob/master/atbash-cipher.json

And need to decide whether to implement decode function as well.

Haven't updated config.json yet either.